### PR TITLE
Generate URLs using the Bioregistry

### DIFF
--- a/app/result_parser.py
+++ b/app/result_parser.py
@@ -21,7 +21,6 @@ def id2url(curie: str) -> Optional[str]:
     :param curie: A compact URI (CURIE) in the form of `prefix:identifier`
     :returns: A URL string if the Bioregistry can construct one, otherwise None.
 
-
     >>> id2url("MESH:C063233")
     'https://meshb.nlm.nih.gov/record/ui?ui=C063233'
     >>> id2url("NCBI:txid10095")

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ xmltodict==0.12.0
 accelerate==0.3.0
 pymongo
 Flask
+bioregistry


### PR DESCRIPTION
Currently, the `id2url` function in the BERN2 Flask web application uses hard-coded logic for converting from entity identifiers (which I call compact URIs, or CURIEs, throughout this pull request) into URLs that can be used in the web pages of the application.

https://github.com/dmis-lab/BERN2/blob/a16b9c7b5f2e753ef5d1f159192a7d0d11f73bd7/app/result_parser.py#L13-L29

Related to the discussion in #3, the [`bioregistry`](https://github.com/biopragmatics/bioregistry) package has a more general version of this function already built-in that can be used like

```python
>>> import bioregistry
>>> bioregistry.get_iri("MESH:C063233")
'https://meshb.nlm.nih.gov/record/ui?ui=C063233'
```

Therefore, I updated the implementation of `id2url` to do a small amount of string preprocessing on NCBI Taxonomy identifiers (as motivated by https://github.com/dmis-lab/BERN2/issues/3#issuecomment-1015952329) and defer to `bioregistry.get_iri` for the remainder of the implementation.

More documentation on `bioregistry.get_iri` can be found [here](https://github.com/biopragmatics/bioregistry#generating-iris). I'm the creator of the Bioregistry and would be happy to answer any questions about it.