### PR TITLE
Add missing requirement to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ xmltodict==0.12.0
 accelerate==0.3.0
 pymongo
 Flask
+faiss


### PR DESCRIPTION
The neural normalizer requires the `faiss` package to be installed:

https://github.com/dmis-lab/BERN2/blob/a16b9c7b5f2e753ef5d1f159192a7d0d11f73bd7/normalizers/neural_normalizer.py#L17

This PR adds `faiss` to the end of the `requirements.txt` file.